### PR TITLE
v0.1.1 - Bugfixes

### DIFF
--- a/rubocop.novaextension/CHANGELOG.md
+++ b/rubocop.novaextension/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.1.1 - 2021-09-11
+
+### Fixed
+
+- Fixed a bug where issues for closed files remained in the sidebar.
+- Fixed a bug where auto-corrected offenses would briefly appear as issues then quickly disappear after auto-correction.
+
 ## 0.1.0 - 2021-09-04
 
 ### Added

--- a/rubocop.novaextension/README.md
+++ b/rubocop.novaextension/README.md
@@ -14,7 +14,7 @@ Let's get started!
 
 # RuboCop for Nova
 
-**RuboCop for Nova** automatically lints all open files, then reports errors and warnings in Nova's **Issues** sidebar and the editor gutter. Issues can even be automatically fixed or silenced with configurable `--auto-correct` options (see Configuration section below).
+**RuboCop for Nova** automatically lints all open Ruby files, then reports errors and warnings in Nova's **Issues** sidebar and the editor gutter. Issues can even be automatically fixed or silenced with configurable `--auto-correct` options (see Configuration section below).
 
 ## Requirements
 

--- a/rubocop.novaextension/Scripts/RuboCopProcess.js
+++ b/rubocop.novaextension/Scripts/RuboCopProcess.js
@@ -72,8 +72,9 @@ class RuboCopProcess {
     try {
       const data = JSON.parse(output);
       const rawOffenses = data["files"][0]["offenses"];
+      const unCorrectedOffenses = rawOffenses.filter(offense => !offense["corrected"]);
 
-      this.offenses = rawOffenses.map(rawOffense => new RuboCopOffense(rawOffense));
+      this.offenses = unCorrectedOffenses.map(offenseData => new RuboCopOffense(offenseData));
 
       return this.offenses
     } catch(error) {

--- a/rubocop.novaextension/Scripts/main.js
+++ b/rubocop.novaextension/Scripts/main.js
@@ -21,6 +21,7 @@ class RuboCop {
 
     let issues = [];
 
+    // Run RuboCop and add issues to Nova's Issues sidebar.
     this.process.inspect(file, options).then((offenses) => {
       offenses.forEach(offense => {
         issues.push(offense.toNovaIssue());
@@ -28,6 +29,16 @@ class RuboCop {
 
       this.issueCollection.set(editor.document.uri, issues);
       return issues;
+    });
+
+    // Add a listener to remove issues from the sidebar when files are closed.
+    editor.onDidDestroy(destroyedEditor => {
+      // Check to see if the same file is open in another tab first:
+      let editorWithSameFile = nova.workspace.textEditors.find(editor => {
+        return editor.document.uri === destroyedEditor.document.uri;
+      });
+
+      if (!editorWithSameFile) this.issueCollection.remove(destroyedEditor.document.uri);
     });
   }
 

--- a/rubocop.novaextension/extension.json
+++ b/rubocop.novaextension/extension.json
@@ -4,7 +4,7 @@
   "organization": "John Ellis",
   "license": "MIT",
   "description": "Complete, configurable RuboCop support for Nova.",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "categories": [
     "issues",
     "formatters"


### PR DESCRIPTION
Fixes one major bug and one minor bug:

- [x] Major: issues lived in the sidebar forever until Nova was restarted. Added a fix to clear issues when files are closed.
- [x] Minor: issues would briefly appear in the sidebar for offenses that were auto-corrected. Now we only report issues that were not auto-corrected.